### PR TITLE
Don't need to require relative

### DIFF
--- a/libraries/windows_sdk_feature.rb
+++ b/libraries/windows_sdk_feature.rb
@@ -1,4 +1,3 @@
-require_relative "./windows_sdk_helpers"
 class WindowsSdkCookbook
   class Resource
     class Feature < Chef::Resource


### PR DESCRIPTION
This causing warnings
