### PR TITLE
Update path from clean path - more info in PR

### DIFF
--- a/libraries/windows_sdk_feature.rb
+++ b/libraries/windows_sdk_feature.rb
@@ -124,7 +124,7 @@ class WindowsSdkCookbook
 
     def default_download_cache_path
       file_cache_dir = Chef::FileCache.create_cache_path("package/")
-      Chef::Util::PathHelper.cleanpath("#{file_cache_dir}/sdksetup-#{requested_version}.exe")
+      Chef::Util::PathHelper.canonical_path("#{file_cache_dir}/sdksetup-#{requested_version}.exe")
     end
 
     def requested_version


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

I'm not sure why this came about... The issue is that the command used during the installation ends up being `C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache\package\sdksetup-8.100.26936.exe" /norestart /quiet /features OptionId.MSIInstallTools` (note the dos style path). For some completely bizarre reason, this causes an error somewhere in the redirect during the download process and you'll end up with a failure, code `-2147023294`.

Looking deeper at the logs, it appears that the `Inst` is being dropped. (See line 179 in the first gist file here https://gist.github.com/scotthain/93b31bd6f9425ce0da27e47ad2955047).

By changing this from the dos style path to the sysdrive style path (or whatever it's called) it appears to do the right thing.